### PR TITLE
MPower_Onsite_Invoice create method override corrected

### DIFF
--- a/mpower/checkout/onsite_invoice.php
+++ b/mpower/checkout/onsite_invoice.php
@@ -41,7 +41,7 @@ class MPower_Onsite_Invoice extends MPower_Checkout_Invoice {
     }
   }
 
-  public function create($account_alias) {
+  public function create($account_alias = false) {
     $invoice_data = array(
       'invoice' => array(
         'items' => $this->items,


### PR DESCRIPTION
The MPower_Onsite_Invoice Create method overload was causing an error due to the presence of another method with the same name but accepting no parameter in base class Power_Checkout_Invoice.

PHP has a weird way of doing method overloads quite different most languages.

method fixed so it rather overrides the method in the base class with an optional parameter.

